### PR TITLE
fix skip ta for debops.nginx

### DIFF
--- a/playbooks/wordpress.yml
+++ b/playbooks/wordpress.yml
@@ -162,7 +162,7 @@
       php__ini_post_max_size: '{{ wordpress__php__post_max_size }}'
 
     - role: debops.nginx
-      tags: [ 'role::nginx', 'skip::ngix' ]
+      tags: [ 'role::nginx', 'skip::nginx' ]
       nginx_acme: False
       nginx_acme_root: '{{ wordpress__nginx__acme_root }}'
       nginx__default_servers: []


### PR DESCRIPTION
Seems like a typo in skip tags for debops.nginx

ngix has been fixed to nginx